### PR TITLE
Demonstrate webac failing source

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContext.java
@@ -61,9 +61,8 @@ public class PropertiesRdfContext extends NodeRdfContext {
     @SuppressWarnings("unchecked")
     private static Stream<Triple> triplesFromProperties(final FedoraResource n, final PropertyToTriple propertyToTriple)
             throws RepositoryException {
-        LOGGER.warn("Creating triples for node: {}", n);
+        LOGGER.trace("Creating triples for node: {}", n);
         return iteratorToStream(n.getNode().getProperties())
-            .peek(x -> LOGGER.warn("Property: {}", x))
             .filter(isInternalProperty.negate())
             .flatMap(propertyToTriple);
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyValueIterator.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyValueIterator.java
@@ -65,7 +65,10 @@ public class PropertyValueIterator extends AbstractIterator<Value> {
 
                 if (property.isMultiple()) {
                     currentValues = Iterators.forArray(property.getValues());
-                    return currentValues.next();
+                    if (currentValues.hasNext()) {
+                        return currentValues.next();
+                    }
+                    return endOfData();
                 }
                 currentValues = null;
                 return property.getValue();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyValueIteratorTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyValueIteratorTest.java
@@ -47,6 +47,10 @@ public class PropertyValueIteratorTest {
     @Mock
     private Property mockMultivaluedProperty;
 
+
+    @Mock
+    private Property mockMultivaluedEmptyProperty;
+
     @Mock
     private Value value1;
 
@@ -65,6 +69,9 @@ public class PropertyValueIteratorTest {
         when(mockMultivaluedProperty.isMultiple()).thenReturn(true);
         when(mockMultivaluedProperty.getValues()).thenReturn(new Value[] { value2, value3 });
         propertyIterator = of(mockProperty, mockMultivaluedProperty).iterator();
+
+        when(mockMultivaluedEmptyProperty.isMultiple()).thenReturn(true);
+        when(mockMultivaluedEmptyProperty.getValues()).thenReturn(new Value[] {});
     }
 
     @Test
@@ -78,6 +85,13 @@ public class PropertyValueIteratorTest {
         testObj = new PropertyValueIterator(mockMultivaluedProperty);
         final List<Value> values = newArrayList(testObj);
         assertTrue(values.containsAll(of(value2, value3)));
+    }
+
+    @Test
+    public void testMultiValueSingleEmptyProperty() {
+        testObj = new PropertyValueIterator(mockMultivaluedEmptyProperty);
+        final List<Value> values = newArrayList(testObj);
+        assertTrue(values.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
@acoburn, I am not sure why a multi-valued property is getting to this point but was not prior to your PR, but this test demonstrates the issue that the WebAC is provoking. Basically, the WebAC test hits the case where there is a multi-valued property:
`jcr:predecessors=[]` ..that has an empty array as the value.

The fix provided here in `PropertyValueIterator` resolves the WebAC issue.